### PR TITLE
Fix black web stream

### DIFF
--- a/babyping.py
+++ b/babyping.py
@@ -201,7 +201,7 @@ def main():
     local_ip = get_local_ip()
     print(f"  Web UI:       http://{local_ip}:{args.port}")
 
-    flask_app = create_app(args)
+    flask_app = create_app(args, frame_buffer)
     web_thread = threading.Thread(
         target=lambda: flask_app.run(host="0.0.0.0", port=args.port, threaded=True),
         daemon=True

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -5,6 +5,7 @@ import json
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
+from babyping import FrameBuffer
 from web import create_app
 
 
@@ -17,7 +18,7 @@ class FakeArgs:
 
 @pytest.fixture
 def client():
-    app = create_app(FakeArgs())
+    app = create_app(FakeArgs(), FrameBuffer())
     app.config["TESTING"] = True
     with app.test_client() as c:
         yield c
@@ -69,7 +70,7 @@ class TestWebSnapshotsEnabled:
         # Create a test snapshot
         frame = np.full((100, 100, 3), 128, dtype=np.uint8)
         cv2.imwrite(str(tmp_path / "2026-02-05T12-00-00.jpg"), frame)
-        app = create_app(args)
+        app = create_app(args, FrameBuffer())
         app.config["TESTING"] = True
         with app.test_client() as c:
             yield c

--- a/web.py
+++ b/web.py
@@ -5,7 +5,7 @@ import time
 from flask import Flask, Response, jsonify, send_from_directory
 
 
-def create_app(args):
+def create_app(args, frame_buffer=None):
     """Create Flask app for the BabyPing web UI."""
     app = Flask(__name__)
 
@@ -17,7 +17,6 @@ def create_app(args):
     @app.route("/stream")
     def stream():
         def generate():
-            from babyping import frame_buffer
             while True:
                 frame_bytes = frame_buffer.get()
                 if frame_bytes is not None:
@@ -29,7 +28,6 @@ def create_app(args):
 
     @app.route("/status")
     def status():
-        from babyping import frame_buffer
         last_motion = frame_buffer.get_last_motion_time()
         return jsonify({
             "sensitivity": args.sensitivity,


### PR DESCRIPTION
## Summary
- Fix black web stream caused by Python `__main__` module import gotcha
- `web.py` was doing `from babyping import frame_buffer` which created a separate module instance with its own empty buffer
- Now passes the `frame_buffer` instance directly from `main()` to `create_app()`

## Test plan
- [x] All 45 tests pass
- [x] Run `python3 babyping.py` and verify web stream at `http://localhost:8080` shows live feed