### PR TITLE
feat: add ROI selection from web UI

### DIFF
--- a/babyping.py
+++ b/babyping.py
@@ -18,6 +18,7 @@ class FrameBuffer:
         self._frame_bytes = None
         self._last_motion_time = None
         self._last_frame_time = None
+        self._roi = None
 
     def update(self, frame_bytes):
         with self._lock:
@@ -39,6 +40,14 @@ class FrameBuffer:
     def get_last_frame_time(self):
         with self._lock:
             return self._last_frame_time
+
+    def set_roi(self, roi):
+        with self._lock:
+            self._roi = roi
+
+    def get_roi(self):
+        with self._lock:
+            return self._roi
 
 
 frame_buffer = FrameBuffer()
@@ -234,6 +243,7 @@ def main():
     roi = parse_roi_string(args.roi)
     if roi is None and not args.no_preview:
         roi = select_roi(cap)
+    frame_buffer.set_roi(roi)
     if roi:
         print(f"  ROI:          {roi}")
 
@@ -278,6 +288,8 @@ def main():
                     send_notification("BabyPing", "Camera reconnected")
                 continue
             consecutive_failures = 0
+
+            roi = frame_buffer.get_roi()
 
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             gray = cv2.GaussianBlur(gray, (21, 21), 0)

--- a/docs/plans/2026-02-06-roi-web-selection-design.md
+++ b/docs/plans/2026-02-06-roi-web-selection-design.md
@@ -1,0 +1,49 @@
+# ROI Web Selection Design
+
+## Goal
+
+Allow users to select, reselect, or clear the motion detection Region of Interest (ROI) directly from the web UI, eliminating the need to restart BabyPing or use CLI flags.
+
+## Design Decisions
+
+- **Draw on stream**: Users click/drag a rectangle on the live video feed (most intuitive)
+- **Session-only**: ROI resets when BabyPing restarts (matches current CLI behavior, keeps things simple)
+- **Overlay only during selection**: The canvas overlay appears while drawing, disappears once confirmed (clean viewing experience; the green ROI rectangle drawn by OpenCV on the stream provides ongoing visibility)
+
+## Architecture
+
+### Backend
+
+**FrameBuffer** gets thread-safe `get_roi()` / `set_roi()` methods. The detection loop reads `frame_buffer.get_roi()` each iteration instead of using a local variable, allowing the web UI to update ROI at any time.
+
+**New endpoint**: `POST /roi` accepts `{"x", "y", "w", "h"}` to set or `null` to clear. Validates non-negative coordinates and positive dimensions.
+
+**Updated endpoint**: `GET /status` now includes `"roi"` field (object or null).
+
+### Frontend
+
+- **ROI button** in the status bar (styled as a status card tag)
+- **Canvas overlay** on the stream for drawing rectangles
+- **Coordinate mapping** handles `object-fit: cover` scaling (CSS pixels to frame pixels)
+- **Touch + mouse** support for mobile and desktop
+- **Confirm / Cancel / Clear** actions after drawing
+- **Resize safety**: exits ROI mode on window resize to prevent stale coordinate mapping
+
+## API
+
+```
+POST /roi
+Body: {"x": 10, "y": 20, "w": 100, "h": 80}  ->  sets ROI
+Body: null                                      ->  clears ROI
+Response: {"roi": {"x": 10, "y": 20, "w": 100, "h": 80}} or {"roi": null}
+
+GET /status
+Response: {...existing fields, "roi": {"x":..,"y":..,"w":..,"h":..} | null}
+```
+
+## Files Changed
+
+- `babyping.py`: FrameBuffer ROI methods, detection loop reads from buffer
+- `web.py`: POST /roi endpoint, status includes ROI, HTML/CSS/JS for selection UI
+- `tests/test_babyping.py`: FrameBuffer ROI tests
+- `tests/test_web.py`: ROI endpoint and UI tests

--- a/tests/test_babyping.py
+++ b/tests/test_babyping.py
@@ -291,6 +291,21 @@ class TestFrameBuffer:
         assert buf.get_last_frame_time() is not None
         assert buf.get_last_frame_time() > 0
 
+    def test_roi_initially_none(self):
+        buf = FrameBuffer()
+        assert buf.get_roi() is None
+
+    def test_set_and_get_roi(self):
+        buf = FrameBuffer()
+        buf.set_roi((10, 20, 100, 80))
+        assert buf.get_roi() == (10, 20, 100, 80)
+
+    def test_clear_roi(self):
+        buf = FrameBuffer()
+        buf.set_roi((10, 20, 100, 80))
+        buf.set_roi(None)
+        assert buf.get_roi() is None
+
 
 # --- parse_args --fps tests ---
 


### PR DESCRIPTION
## Summary
- Adds the ability to select, reselect, or clear the motion detection Region of Interest (ROI) directly from the web UI
- Users draw a rectangle on the live stream via a canvas overlay (mouse + touch), then confirm/cancel/clear
- Backend receives coordinates via `POST /roi`, detection loop picks up changes each frame via thread-safe FrameBuffer
- ROI button in status bar highlights amber when active; coordinate mapping handles `object-fit: cover` scaling

## Test plan
- [x] 70 tests pass (8 new: FrameBuffer ROI methods, POST /roi set/clear/validation, GET /status includes ROI, HTML includes ROI UI elements)
- [ ] Manual: open web UI, tap ROI button, draw rectangle on stream, confirm — verify green rectangle appears on stream
- [ ] Manual: tap ROI button again, tap Clear — verify full-frame detection resumes
- [ ] Manual: test on mobile (touch draw) and desktop (mouse draw)
- [ ] Manual: resize browser while in ROI mode — verify overlay exits cleanly