### PR TITLE
feat: configurable sensitivity and FPS from web UI

### DIFF
--- a/babyping.py
+++ b/babyping.py
@@ -25,6 +25,8 @@ class FrameBuffer:
         self._audio_enabled = False
         self._motion_alerts_enabled = True
         self._sound_alerts_enabled = True
+        self._sensitivity = "medium"
+        self._fps = 10
 
     def update(self, frame_bytes):
         with self._lock:
@@ -94,6 +96,22 @@ class FrameBuffer:
     def get_sound_alerts_enabled(self):
         with self._lock:
             return self._sound_alerts_enabled
+
+    def set_sensitivity(self, sensitivity):
+        with self._lock:
+            self._sensitivity = sensitivity
+
+    def get_sensitivity(self):
+        with self._lock:
+            return self._sensitivity
+
+    def set_fps(self, fps):
+        with self._lock:
+            self._fps = fps
+
+    def get_fps(self):
+        with self._lock:
+            return self._fps
 
 
 frame_buffer = FrameBuffer()
@@ -303,6 +321,8 @@ def open_camera(index):
 
 def main():
     args = parse_args()
+    frame_buffer.set_sensitivity(args.sensitivity)
+    frame_buffer.set_fps(args.fps)
     threshold = SENSITIVITY_THRESHOLDS[args.sensitivity]
     print(f"BabyPing starting — camera={args.camera}, sensitivity={args.sensitivity} ({threshold}px²), cooldown={args.cooldown}s")
 
@@ -389,6 +409,7 @@ def main():
             consecutive_failures = 0
 
             roi = frame_buffer.get_roi()
+            threshold = SENSITIVITY_THRESHOLDS[frame_buffer.get_sensitivity()]
 
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             gray = cv2.GaussianBlur(gray, (21, 21), 0)
@@ -457,7 +478,7 @@ def main():
             if key == ord("q"):
                 break
 
-            throttle_fps(frame_start, args.fps)
+            throttle_fps(frame_start, frame_buffer.get_fps())
     except KeyboardInterrupt:
         print("\nStopping...")
     finally:

--- a/tests/test_babyping.py
+++ b/tests/test_babyping.py
@@ -357,6 +357,28 @@ class TestFrameBuffer:
         buf.set_sound_alerts_enabled(True)
         assert buf.get_sound_alerts_enabled() is True
 
+    def test_sensitivity_default(self):
+        buf = FrameBuffer()
+        assert buf.get_sensitivity() == "medium"
+
+    def test_set_and_get_sensitivity(self):
+        buf = FrameBuffer()
+        buf.set_sensitivity("high")
+        assert buf.get_sensitivity() == "high"
+        buf.set_sensitivity("low")
+        assert buf.get_sensitivity() == "low"
+
+    def test_fps_default(self):
+        buf = FrameBuffer()
+        assert buf.get_fps() == 10
+
+    def test_set_and_get_fps(self):
+        buf = FrameBuffer()
+        buf.set_fps(30)
+        assert buf.get_fps() == 30
+        buf.set_fps(5)
+        assert buf.get_fps() == 5
+
 
 # --- parse_args audio flag tests ---
 


### PR DESCRIPTION
## Summary
- Tap the **sensitivity pill** in the status bar to cycle through Low → Medium → High
- Tap the **FPS pill** to cycle through 5 → 10 → 15 → 30
- Changes apply immediately to the detection loop and MJPEG stream
- `POST /settings` endpoint accepts `{"sensitivity": "low"|"medium"|"high", "fps": 5|10|15|30}`
- State synced from `/status` on every poll for multi-tab consistency
- Invalid values are silently ignored (server keeps current value)

## Test plan
- [x] 178 tests passing (10 new: 4 FrameBuffer + 6 web)
- [ ] Verify sensitivity cycling updates detection threshold in real-time
- [ ] Verify FPS cycling changes stream smoothness immediately
- [ ] Verify settings persist across page refreshes (synced from server)
- [ ] Verify invalid POST values are rejected gracefully