### PR TITLE
fix: production hardening — critical issues for 24/7 deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
           python-version: "3.11"
           cache: pip
       - run: sudo apt-get update && sudo apt-get install -y libportaudio2
-      - run: pip install opencv-python-headless numpy flask sounddevice pytest
+      - run: pip install opencv-python-headless numpy flask waitress sounddevice pytest
       - run: pytest tests/ -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           cache: pip
 
       - run: sudo apt-get update && sudo apt-get install -y libportaudio2
-      - run: pip install opencv-python-headless numpy flask sounddevice pytest
+      - run: pip install opencv-python-headless numpy flask waitress sounddevice pytest
       - run: pytest tests/ -v
 
       - name: Extract version from tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "babyping"
-version = "1.0.0"
+version = "2.0.0"
 description = "Lightweight baby monitor with motion detection, macOS notifications, and a local web UI"
 readme = "README.md"
 license = {text = "MIT"}
@@ -13,6 +13,7 @@ dependencies = [
     "opencv-python>=4.8",
     "numpy>=1.24",
     "flask>=3.0",
+    "waitress>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 opencv-python
 numpy
 flask
+waitress
 sounddevice


### PR DESCRIPTION
## Summary
Fixes 5 critical and 3 high-severity issues identified during production readiness review:

**Critical fixes:**
- MJPEG stream generator now handles `GeneratorExit` to prevent leaked threads on client disconnect
- Web server uses waitress (production WSGI) instead of Flask dev server, with fallback
- Audio monitor health check in main loop — detects dead thread, notifies user, disables audio
- Audio callback race condition fixed — all calibration state mutations now under lock
- CPU spin on camera frame failures — added `time.sleep(0.1)` before `continue`

**High fixes:**
- `snap_path` initialized to `None` to prevent potential `UnboundLocalError`
- `cv2.waitKey` only called when preview window is active (fixes headless mode)
- `/settings` endpoint handles non-integer FPS input gracefully (no more 500 errors)

**Other:**
- Audio callback now logs stream status warnings (overflow, underflow)
- Bumped `pyproject.toml` version to 2.0.0
- Added waitress to dependencies (requirements.txt, pyproject.toml, CI workflows)
- 15 new tests covering all fixes (189 total passing)

## Test plan
- [x] All 189 tests pass locally
- [ ] CI passes on PR
- [ ] Verify waitress serves web UI correctly
- [ ] Verify MJPEG stream cleanup on tab close
- [ ] Verify audio health notification on device disconnect